### PR TITLE
Clearer error when no value is specified

### DIFF
--- a/attrib/gatttool.c
+++ b/attrib/gatttool.c
@@ -328,7 +328,7 @@ static gboolean characteristics_write(gpointer user_data)
 	}
 
 	if (opt_value == NULL || opt_value[0] == '\0') {
-		g_printerr("A value is required\n");
+		g_printerr("A value is required. Please specify one with the --value option.\n");
 		goto error;
 	}
 


### PR DESCRIPTION
There are more places where this type of suggestion can be added to the error message. I only propose one. 